### PR TITLE
Add the ability to control permissions on a vhost's docroot directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,7 +225,7 @@ class simple_apache(
     $access_logroot = dirname($access_log)
     $docroot = pick(dig($opts, 'docroot'), "${vhost_dir}/${key}")
 
-    if ! defined(File[$error_logroot]) {
+    if ! defined(Mkdir::P[$error_logroot]) {
       mkdir::p { $error_logroot:
         ensure => directory,
         owner  => $apache_user,
@@ -235,7 +235,7 @@ class simple_apache(
       }
     }
 
-    if ! defined(File[$access_logroot]) {
+    if ! defined(Mkdir::P[$access_logroot]) {
       mkdir::p { $access_logroot:
         ensure => directory,
         owner  => $apache_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -245,7 +245,6 @@ class simple_apache(
 
 
     mkdir::p { $docroot:
-      path   => $docroot,
       owner  => $docroot_owner,
       group  => $docroot_group,
       mode   => $docroot_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,17 +165,13 @@ class simple_apache(
     require => $package_ref,
   }
 
-  mkdir::p { $vhost_dir:
-    ensure => directory,
-  }
+  mkdir::p { $vhost_dir: }
 
   mkdir::p { $vhost_enabled_dir:
-    ensure => directory,
     notify => $service_ref,
   }
 
   mkdir::p { $logroot:
-    ensure => directory,
     owner  => $apache_user,
     group  => $apache_group,
     notify => $service_ref,
@@ -227,7 +223,6 @@ class simple_apache(
 
     if ! defined(Mkdir::P[$error_logroot]) {
       mkdir::p { $error_logroot:
-        ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
         mode   => "0640",
@@ -237,7 +232,6 @@ class simple_apache(
 
     if ! defined(Mkdir::P[$access_logroot]) {
       mkdir::p { $access_logroot:
-        ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
         mode   => "0640",
@@ -247,7 +241,6 @@ class simple_apache(
 
 
     mkdir::p { $docroot:
-      ensure => directory,
       notify => $service_ref,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,13 +165,17 @@ class simple_apache(
     require => $package_ref,
   }
 
-  mkdir::p { $vhost_dir: }
+  file { $vhost_dir: 
+    ensure => directory,
+  }
 
-  mkdir::p { $vhost_enabled_dir:
+  file { $vhost_enabled_dir:
+    ensure => directory,
     notify => $service_ref,
   }
 
-  mkdir::p { $logroot:
+  file { $logroot:
+    ensure => directory,
     owner  => $apache_user,
     group  => $apache_group,
     notify => $service_ref,
@@ -225,8 +229,9 @@ class simple_apache(
     $docroot_mode = pick(dig($opts, 'docroot', 'mode'), '0755')
 
 
-    if ! defined(Mkdir::P[$error_logroot]) {
-      mkdir::p { $error_logroot:
+    if ! defined(File[$error_logroot]) {
+      file { $error_logroot:
+        ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
         mode   => "0640",
@@ -234,8 +239,9 @@ class simple_apache(
       }
     }
 
-    if ! defined(Mkdir::P[$access_logroot]) {
-      mkdir::p { $access_logroot:
+    if ! defined(File[$access_logroot]) {
+      file { $access_logroot:
+        ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
         mode   => "0640",
@@ -244,7 +250,8 @@ class simple_apache(
     }
 
 
-    mkdir::p { $docroot:
+    file { $docroot:
+      ensure => directory,
       owner  => $docroot_owner,
       group  => $docroot_group,
       mode   => $docroot_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -245,6 +245,7 @@ class simple_apache(
 
 
     mkdir::p { $docroot:
+      path   => $docroot,
       owner  => $docroot_owner,
       group  => $docroot_group,
       mode   => $docroot_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,7 +165,7 @@ class simple_apache(
     require => $package_ref,
   }
 
-  file { $vhost_dir: 
+  file { $vhost_dir:
     ensure => directory,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -219,7 +219,11 @@ class simple_apache(
     $error_logroot = dirname($error_log)
     $access_log = pick(dig($opts, 'access_log'), "${logroot}/${key}-access_log")
     $access_logroot = dirname($access_log)
-    $docroot = pick(dig($opts, 'docroot'), "${vhost_dir}/${key}")
+    $docroot = pick(dig($opts, 'docroot', 'path'), "${vhost_dir}/${key}")
+    $docroot_owner = pick(dig($opts, 'docroot', 'owner'), 'root')
+    $docroot_group = pick(dig($opts, 'docroot', 'group'), 'root')
+    $docroot_mode = pick(dig($opts, 'docroot', 'mode'), '0755')
+
 
     if ! defined(Mkdir::P[$error_logroot]) {
       mkdir::p { $error_logroot:
@@ -241,6 +245,9 @@ class simple_apache(
 
 
     mkdir::p { $docroot:
+      owner  => $docroot_owner,
+      group  => $docroot_group,
+      mode   => $docroot_mode,
       notify => $service_ref,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,16 +165,16 @@ class simple_apache(
     require => $package_ref,
   }
 
-  file { $vhost_dir:
+  mkdir::p { $vhost_dir:
     ensure => directory,
   }
 
-  file { $vhost_enabled_dir:
+  mkdir::p { $vhost_enabled_dir:
     ensure => directory,
     notify => $service_ref,
   }
 
-  file { $logroot:
+  mkdir::p { $logroot:
     ensure => directory,
     owner  => $apache_user,
     group  => $apache_group,
@@ -226,7 +226,7 @@ class simple_apache(
     $docroot = pick(dig($opts, 'docroot'), "${vhost_dir}/${key}")
 
     if ! defined(File[$error_logroot]) {
-      file { $error_logroot:
+      mkdir::p { $error_logroot:
         ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
@@ -236,7 +236,7 @@ class simple_apache(
     }
 
     if ! defined(File[$access_logroot]) {
-      file { $access_logroot:
+      mkdir::p { $access_logroot:
         ensure => directory,
         owner  => $apache_user,
         group  => $apache_group,
@@ -246,7 +246,7 @@ class simple_apache(
     }
 
 
-    file { $docroot:
+    mkdir::p { $docroot:
       ensure => directory,
       notify => $service_ref,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -27,10 +27,6 @@
     {
       "name":"geoffwilliams-filemagic",
       "version_requirement": "0.4.0"
-    },
-    {
-      "name":"flypenguin-mkdir",
-      "version_requirement": "1.0.4"
     }
   ],
   "data_provider": null,

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,10 @@
     {
       "name":"geoffwilliams-filemagic",
       "version_requirement": "0.4.0"
+    },
+    {
+      "name":"flypenguin-mkdir",
+      "version_requirement": "1.0.4"
     }
   ],
   "data_provider": null,


### PR DESCRIPTION
Sample hiera data:

simple_apache::vhosts_enabled:
&nbsp;&nbsp;'mysite.example.com': 
&nbsp;&nbsp;&nbsp;&nbsp;raw: true
&nbsp;&nbsp;&nbsp;&nbsp;docroot: 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: /var/www/html/mysite.example.com
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode: '2750'
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;owner: deployuser
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group: apache